### PR TITLE
add unlock to undelegate calls

### DIFF
--- a/src/lifecycle/index.tsx
+++ b/src/lifecycle/index.tsx
@@ -618,6 +618,8 @@ export class Updater {
     if (api) {
       let txs = tracks.map((track) => undelegate(api, track));
       if (unlockTarget) {
+        // delegation locks are put on balance per each delegated track.
+        // here all tracks that are being undelegated are bateched with an unlock call to lift their locks.
         const unlockTxs = tracks.map((track) =>
           unlock(api, track, unlockTarget)
         );

--- a/src/ui/components/delegation/delegateModal/Undelegate.tsx
+++ b/src/ui/components/delegation/delegateModal/Undelegate.tsx
@@ -45,7 +45,8 @@ export function UndelegateModal({
   // set fee
   useEffect(() => {
     if (open && connectedAddress && balance && tracks.length > 0) {
-      updater.undelegate(tracks.map((track) => track.id)).then(async (tx) => {
+      const trackIds = tracks.map((track) => track.id);
+      updater.undelegate(trackIds, connectedAddress).then(async (tx) => {
         if (tx.type === 'ok') {
           const fee = await calcEstimatedFee(tx.value, connectedAddress);
           setFee(fee);
@@ -59,7 +60,8 @@ export function UndelegateModal({
     signer,
   }: SigningAccount) => {
     try {
-      const txs = await updater.undelegate(tracks.map((track) => track.id));
+      const trackIds = tracks.map((track) => track.id);
+      const txs = await updater.undelegate(trackIds, address);
       if (txs.type == 'ok') {
         await signAndSend(address, signer, txs.value, (result) =>
           updater.handleCallResult(result)


### PR DESCRIPTION
if No conviction account can undelegate/unlock at any time.
To simplify we will call unlock as part of undelegate to unlock the tokens when user undelegates.

should address #282 