### PR TITLE
Convert address format to network ss58

### DIFF
--- a/src/contexts/Account.tsx
+++ b/src/contexts/Account.tsx
@@ -46,7 +46,6 @@ const AccountProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   const getWalletsAccounts = async () => {
-    console.log('get accounts');
     let signingAccounts = new Map<string, SigningAccount>();
     for (const wallet of wallets) {
       const {
@@ -89,9 +88,12 @@ const AccountProvider = ({ children }: { children: React.ReactNode }) => {
     return walletState.get(title) === 'connected';
   };
 
-  const setConnectedAccount = (signingAccount: SigningAccount | undefined) => {
+  const setConnectedAccount = (
+    signingAccount: SigningAccount | undefined,
+    persist = true
+  ) => {
     const connectedAddress = signingAccount?.account.address;
-    AccountStorage.setConnectedAddress(connectedAddress || '');
+    persist && AccountStorage.setConnectedAddress(connectedAddress || '');
     _setConnectedAccount(signingAccount);
     updater.setConnectedAddress(connectedAddress || null);
   };
@@ -102,7 +104,12 @@ const AccountProvider = ({ children }: { children: React.ReactNode }) => {
     if (storedConnectedAddress) {
       loadConnectedAccount().then((signingAccount) => {
         if (signingAccount) {
-          setConnectedAccount(signingAccount);
+          // connected account might have changed, persist the address in storage
+          setConnectedAccount(signingAccount, true);
+        } else {
+          // was not able to load the connected account based on storedConnectedAddress,
+          // hence (persist=false) to reset the state but not clearing the local storage value .
+          setConnectedAccount(undefined, false);
         }
       });
     }

--- a/src/contexts/Wallets.tsx
+++ b/src/contexts/Wallets.tsx
@@ -87,7 +87,10 @@ const WalletProvider = ({ children }: { children: React.ReactNode }) => {
     new InjectedWalletProvider({}, APP_NAME),
   ]);
   return (
-    <PolkadotWalletsContextProvider walletAggregator={walletAggregator}>
+    <PolkadotWalletsContextProvider
+      walletAggregator={walletAggregator}
+      initialWaitMs={20}
+    >
       <WalletProviderInner>{children}</WalletProviderInner>
     </PolkadotWalletsContextProvider>
   );

--- a/src/lifecycle/types.ts
+++ b/src/lifecycle/types.ts
@@ -31,6 +31,7 @@ export type AccountChainState = {
 };
 
 export type ChainProperties = {
+  genesisHash?: `0x${string}`;
   ss58Format?: number;
   tokenDecimals: Array<number>;
   tokenSymbols: Array<string>;

--- a/src/ui/components/accounts/AccountList.tsx
+++ b/src/ui/components/accounts/AccountList.tsx
@@ -1,14 +1,17 @@
 import type { SigningAccount } from '../../../types';
 import { useMemo } from 'react';
 import Account from './Account.js';
+import { encodeAddress } from '@polkadot/keyring';
 
 export const AccountList = ({
   accounts,
   connectedAccount,
+  ss58Format,
   accountConnectHandler,
 }: {
   accounts: Map<string, SigningAccount>;
   connectedAccount: SigningAccount | undefined;
+  ss58Format: number | undefined;
   accountConnectHandler: (account: SigningAccount | undefined) => void;
 }) => {
   const otherAccounts = useMemo(() => {
@@ -23,7 +26,10 @@ export const AccountList = ({
         {connectedAccount?.account && (
           <Account
             name={connectedAccount.account.name || ''}
-            address={connectedAccount.account.address}
+            address={encodeAddress(
+              connectedAccount.account.address,
+              ss58Format
+            )}
             state={{ isConnected: true }}
             clickHandler={() => {
               // disconnect
@@ -39,7 +45,7 @@ export const AccountList = ({
             <Account
               key={account.address}
               name={account.name || ''}
-              address={account.address}
+              address={encodeAddress(account.address, ss58Format)}
               state={{ isConnected: false }}
               clickHandler={() => accountConnectHandler(signingAccount)}
             />

--- a/src/ui/components/accounts/ConnectButton.tsx
+++ b/src/ui/components/accounts/ConnectButton.tsx
@@ -10,6 +10,7 @@ import { AccountList } from './AccountList.js';
 import { WalletsList } from './WalletList.js';
 import { ConnectCard } from './ConnectCard.js';
 import { ChevronRightIcon, WalletIcon } from '../../icons/index.js';
+import { extractChainInfo, useAppLifeCycle } from '../../../lifecycle';
 
 type ConnectViews = 'wallets' | 'accounts';
 
@@ -54,6 +55,8 @@ const AccountView = ({
     signingAccount: SigningAccount | undefined
   ) => Promise<void>;
 }) => {
+  const { state } = useAppLifeCycle();
+  const { ss58 } = extractChainInfo(state) || {};
   const { connectedAccount, walletsAccounts } = useAccount();
   return (
     <>
@@ -71,6 +74,7 @@ const AccountView = ({
         accounts={walletsAccounts}
         connectedAccount={connectedAccount}
         accountConnectHandler={accountConnectHandler}
+        ss58Format={ss58}
       />
     </>
   );


### PR DESCRIPTION
These:
- Shows account addresses based on network ss58 format.
- filters account based on the genesis hash if they are assigned to a specific network in the wallet.